### PR TITLE
Fix peal enchantment crash

### DIFF
--- a/src/main/java/ru/feytox/etherology/util/misc/ShockwaveUtil.java
+++ b/src/main/java/ru/feytox/etherology/util/misc/ShockwaveUtil.java
@@ -155,6 +155,8 @@ public class ShockwaveUtil {
     }
 
     private static void trySchedulePeal(World world, PlayerEntity attacker, Entity target, Vec3d shockPos, double knockbackStrength) {
+        if (target == null) return;
+
         int pealLevel = EtherEnchantments.getLevel(world, EtherEnchantments.PEAL, attacker);
         if (world.isClient || pealLevel <= 0) return;
 


### PR DESCRIPTION
Fixed NPE when scheduling Peal echantment. Target entity for echantment happens to be null when hitting a minecart **with peal** (for some reason)