### PR TITLE
Spinner performance fix

### DIFF
--- a/src/main/java/ru/feytox/etherology/block/generators/AbstractGeneratorBlockEntity.java
+++ b/src/main/java/ru/feytox/etherology/block/generators/AbstractGeneratorBlockEntity.java
@@ -44,7 +44,6 @@ public abstract class AbstractGeneratorBlockEntity extends TickableBlockEntity i
     private EssenceSupplier cachedSeal;
     @Getter @Setter
     private boolean isSearchingStopped;
-    private int ticksUntilSealCheck = 0;
 
     public AbstractGeneratorBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -127,11 +126,8 @@ public abstract class AbstractGeneratorBlockEntity extends TickableBlockEntity i
         if (state.get(STALLED) || isMess) return;
 
         boolean isInSeal = getCachedSeal().isPresent();
-        if (ticksUntilSealCheck > 0) {
-            ticksUntilSealCheck--;
-        } else {
+        if (world.getTime() % 20 == 0) {
             isInSeal = isInSeal(world);
-            ticksUntilSealCheck = 20;
         }
 
         Random random = world.getRandom();

--- a/src/main/java/ru/feytox/etherology/block/generators/AbstractGeneratorBlockEntity.java
+++ b/src/main/java/ru/feytox/etherology/block/generators/AbstractGeneratorBlockEntity.java
@@ -44,6 +44,7 @@ public abstract class AbstractGeneratorBlockEntity extends TickableBlockEntity i
     private EssenceSupplier cachedSeal;
     @Getter @Setter
     private boolean isSearchingStopped;
+    private int ticksUntilSealCheck = 0;
 
     public AbstractGeneratorBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -125,7 +126,14 @@ public abstract class AbstractGeneratorBlockEntity extends TickableBlockEntity i
     public void generateTick(ServerWorld world, BlockState state) {
         if (state.get(STALLED) || isMess) return;
 
-        boolean isInSeal = isInSeal(world);
+        boolean isInSeal = getCachedSeal().isPresent();
+        if (ticksUntilSealCheck > 0) {
+            ticksUntilSealCheck--;
+        } else {
+            isInSeal = isInSeal(world);
+            ticksUntilSealCheck = 20;
+        }
+
         Random random = world.getRandom();
         if (nextGenTime-- > 0) {
             if (isInSeal && random.nextDouble() <= 0.5) nextGenTime -= random.nextBetween(0, 1);


### PR DESCRIPTION
Every tick spinners poll their surroundings for a seal. Fixed it to check for seals every 20 ticks to reduce lag. I think 20 ticks is reasonable since seals don't spawn after worldgen and cannot be placed in any way in survival.
_before:_ (look at the mspt in bossbar)
![image](https://github.com/user-attachments/assets/2d8bfb52-c283-485e-8ad9-e149e159b4aa)
**after:** (much better)
![image](https://github.com/user-attachments/assets/b225ab5c-1168-42e4-95b3-37396ee8bb9f)
