### PR TITLE
Beamer dupe fix

### DIFF
--- a/src/main/java/ru/feytox/etherology/block/beamer/BeamerBlock.java
+++ b/src/main/java/ru/feytox/etherology/block/beamer/BeamerBlock.java
@@ -6,6 +6,8 @@ import net.minecraft.block.piston.PistonBehavior;
 import net.minecraft.component.type.SuspiciousStewEffectsComponent;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.item.ItemPlacementContext;
+import net.minecraft.item.ItemStack;
+import net.minecraft.loot.context.LootContextParameterSet;
 import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.BlockSoundGroup;
@@ -43,6 +45,15 @@ public class BeamerBlock extends PlantBlock implements Fertilizable, Registrable
                 .with(AGE, 0)
                 .with(IS_FARMLAND, false)
         );
+    }
+
+    @Override
+    protected List<ItemStack> getDroppedStacks(BlockState state, LootContextParameterSet.Builder builder) {
+        if (state.get(AGE) == MAX_AGE) {
+            return List.of(new ItemStack(DecoBlockItems.BEAM_FRUIT));
+        } else {
+            return List.of(new ItemStack(DecoBlockItems.BEAMER_SEEDS));
+        }
     }
 
     @Override
@@ -101,7 +112,7 @@ public class BeamerBlock extends PlantBlock implements Fertilizable, Registrable
 
     @Override
     public void randomTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
-        if (random.nextInt(100) == 0 && !isMature(state)) {
+        if (random.nextInt(100) < 5 && !isMature(state)) {
             world.setBlockState(pos, state.with(AGE, state.get(AGE) + 1), Block.NOTIFY_LISTENERS);
         }
     }

--- a/src/main/java/ru/feytox/etherology/util/misc/ShockwaveUtil.java
+++ b/src/main/java/ru/feytox/etherology/util/misc/ShockwaveUtil.java
@@ -155,6 +155,8 @@ public class ShockwaveUtil {
     }
 
     private static void trySchedulePeal(World world, PlayerEntity attacker, Entity target, Vec3d shockPos, double knockbackStrength) {
+        if (target == null) return;
+
         int pealLevel = EtherEnchantments.getLevel(world, EtherEnchantments.PEAL, attacker);
         if (world.isClient || pealLevel <= 0) return;
 

--- a/src/main/java/ru/feytox/etherology/util/misc/ShockwaveUtil.java
+++ b/src/main/java/ru/feytox/etherology/util/misc/ShockwaveUtil.java
@@ -155,8 +155,6 @@ public class ShockwaveUtil {
     }
 
     private static void trySchedulePeal(World world, PlayerEntity attacker, Entity target, Vec3d shockPos, double knockbackStrength) {
-        if (target == null) return;
-
         int pealLevel = EtherEnchantments.getLevel(world, EtherEnchantments.PEAL, attacker);
         if (world.isClient || pealLevel <= 0) return;
 


### PR DESCRIPTION
Previously you could harvest full grown beam fruits from plants with 0% growth progress. Now when the plant isn't fully grown it drops seeds, otherwise the fruit itself